### PR TITLE
Ability to configure rootkit options and toggle alert_new_files

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -6,6 +6,7 @@ class ossec::client(
   $ossec_server_hostname   = undef,
   $ossec_server_port       = '1514',
   $ossec_scanpaths         = [],
+  $ossec_alert_new_files   = 'yes',
   $ossec_emailnotification = 'yes',
   $ossec_ignorepaths       = [],
   $ossec_local_files       = $::ossec::params::default_local_files,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -24,6 +24,9 @@ class ossec::client(
   $max_clients             = 3000,
   $ar_repeated_offenders   = '',
   $service_has_status      = $::ossec::params::service_has_status,
+  $rootkit_files           = $::ossec::params::rootkit_files,
+  $rootkit_trojans         = $::ossec::params::rootkit_trojans,
+  $rootcheck_frequency     = 36000,
 ) inherits ossec::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,9 @@ class ossec::params {
       $processlist_owner = 'root'
       $processlist_group = 'ossec'
 
+      $rootkit_files = '/var/ossec/etc/shared/rootkit_files.txt'
+      $rootkit_trojans = '/var/ossec/etc/shared/rootkit_trojans.txt'
+
       case $::osfamily {
         'Debian': {
 
@@ -96,6 +99,9 @@ class ossec::params {
       $server_package = ''
 
       $service_has_status  = true
+
+      $rootkit_files = ''
+      $rootkit_trojans = ''
 
       # Pushed by shared agent config now
       $default_local_files = {}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -10,6 +10,7 @@ class ossec::server (
   $ossec_email_alert_level             = 7,
   $ossec_ignorepaths                   = [],
   $ossec_scanpaths                     = [ {'path' => '/etc,/usr/bin,/usr/sbin', 'report_changes' => 'no', 'realtime' => 'no'}, {'path' => '/bin,/sbin', 'report_changes' => 'yes', 'realtime' => 'yes'} ],
+  $ossec_alert_new_files               = 'yes',
   $ossec_white_list                    = [],
   $ossec_extra_rules_config            = [],
   $ossec_local_files                   = $::ossec::params::default_local_files,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -35,7 +35,10 @@ class ossec::server (
   $syslog_output_server                = undef,
   $syslog_output_format                = undef,
   $local_decoder_template              = 'ossec/local_decoder.xml.erb',
-  $local_rules_template                = 'ossec/local_rules.xml.erb'
+  $local_rules_template                = 'ossec/local_rules.xml.erb',
+  $rootkit_files                       = $::ossec::params::rootkit_files,
+  $rootkit_trojans                     = $::ossec::params::rootkit_trojans,
+  $rootcheck_frequency                 = 36000,
 ) inherits ossec::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -94,7 +94,7 @@
   <syscheck>
     <!-- Frequency that syscheck is executed -->
     <frequency><%= @ossec_check_frequency %></frequency>
-    <alert_new_files>yes</alert_new_files>
+    <alert_new_files><%= @ossec_alert_new_files %></alert_new_files>
     <auto_ignore><%= @ossec_auto_ignore %></auto_ignore>
 
    <!-- Directories to check  (perform all possible verifications) -->

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -110,11 +110,20 @@
 <% end %>
   </syscheck>
 
-<% if @ossec_rootcheck == false then -%>
   <rootcheck>
+<% if @ossec_rootcheck == false then -%>
     <disabled>yes</disabled>
+<% else -%>
+    <frequency><%= @rootcheck_frequency %></frequency>
+  <%- if @rootkit_files then -%>
+    <rootkit_files><%= @rootkit_files %></rootkit_files>
+  <%- end -%>
+  <%- if @rootkit_trojans then -%>
+    <rootkit_trojans><%= @rootkit_trojans %></rootkit_trojans>
+  <%- end -%>
+<%- end -%>
   </rootcheck>
-<% end -%>
+
 <% if @ossec_active_response == false then -%>
   <active-response>
     <disabled>yes</disabled>

--- a/templates/10_ossec_agent.conf.erb
+++ b/templates/10_ossec_agent.conf.erb
@@ -27,11 +27,19 @@
 <% end %>
   </syscheck>
 
-<% if @ossec_rootcheck == false then -%>
   <rootcheck>
+<% if @ossec_rootcheck == false then -%>
     <disabled>yes</disabled>
+<% else -%>
+    <frequency><%= @rootcheck_frequency %></frequency>
+  <%- if @rootkit_files then -%>
+    <rootkit_files><%= @rootkit_files %></rootkit_files>
+  <%- end -%>
+  <%- if @rootkit_trojans then -%>
+    <rootkit_trojans><%= @rootkit_trojans %></rootkit_trojans>
+  <%- end -%>
+<%- end -%>
   </rootcheck>
-<% end -%>
 
 <% if @ossec_active_response == false then -%>
   <active-response>


### PR DESCRIPTION
**1:** Adds default options for the `<rootcheck>` configuration in the `ossec.conf` for both the server and client. When rootcheck is enabled, 3 new options will be defined (where applicable). Previously it was not possible to define these options at all.

**2:** Adds the ability to toggle the `alert_new_files` option in the `<syscheck>` configuration. This was previous hardcoded to 'yes' (also now the default).


**More information:**
```
  $ossec_alert_new_files   = 'yes',
  $rootkit_files           = $::ossec::params::rootkit_files,
  $rootkit_trojans         = $::ossec::params::rootkit_trojans,
  $rootcheck_frequency     = 36000,
```

Resulting segment from `ossec.conf`:
```
   <syscheckcheck>
     <alert_new_files>yes</alert_new_files>
   </syscheckcheck>

   <rootcheck>
     <frequency>36000</frequency>
     <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
     <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
   </rootcheck>
```

Without this change, the `ossec-syscheck` process will not perform the rootkit files/trojans pattern checks and will only do generic rootkit scans.