### PR TITLE
Allow configuration of syslog remote, custom alert output and regex ignore paths

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,6 +9,7 @@ class ossec::client(
   $ossec_alert_new_files   = 'yes',
   $ossec_emailnotification = 'yes',
   $ossec_ignorepaths       = [],
+  $ossec_ignorepaths_regex = [],
   $ossec_local_files       = $::ossec::params::default_local_files,
   $ossec_check_frequency   = 79200,
   $ossec_prefilter         = false,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -22,6 +22,8 @@ class ossec::server (
   $ossec_prefilter                     = false,
   $ossec_service_provider              = $::ossec::params::ossec_service_provider,
   $ossec_server_port                   = '1514',
+  $ossec_syslog_server                 = false,
+  $ossec_syslog_server_port            = '514',
   $use_mysql                           = false,
   $mariadb                             = false,
   $mysql_hostname                      = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,6 +9,7 @@ class ossec::server (
   $ossec_global_stat_level             = 8,
   $ossec_email_alert_level             = 7,
   $ossec_ignorepaths                   = [],
+  $ossec_ignorepaths_regex             = [],
   $ossec_scanpaths                     = [ {'path' => '/etc,/usr/bin,/usr/sbin', 'report_changes' => 'no', 'realtime' => 'no'}, {'path' => '/bin,/sbin', 'report_changes' => 'yes', 'realtime' => 'yes'} ],
   $ossec_alert_new_files               = 'yes',
   $ossec_white_list                    = [],

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -24,6 +24,7 @@ class ossec::server (
   $ossec_server_port                   = '1514',
   $ossec_syslog_server                 = false,
   $ossec_syslog_server_port            = '514',
+  $ossec_custom_alert_output           = '',
   $use_mysql                           = false,
   $mariadb                             = false,
   $mysql_hostname                      = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -25,6 +25,7 @@ class ossec::server (
   $ossec_server_port                   = '1514',
   $ossec_syslog_server                 = false,
   $ossec_syslog_server_port            = '514',
+  $ossec_syslog_allowed_ips            = ['0.0.0.0/0'],
   $ossec_custom_alert_output           = '',
   $use_mysql                           = false,
   $mariadb                             = false,

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -134,6 +134,12 @@
     <connection>secure</connection>
     <port><%= @ossec_server_port %></port>
   </remote>
+<% if @ossec_syslog_server == true then -%>
+  <remote>
+    <connection>syslog</connection>
+    <port><%= @ossec_syslog_server_port %></port>
+  </remote>
+<% end -%>
 
   <alerts>
     <log_alert_level>1</log_alert_level>

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -15,6 +15,9 @@
     <host_information><%= @ossec_global_host_information_level %></host_information>
     <% @ossec_white_list.each do |ipaddress| -%><white_list><%= ipaddress %></white_list>
     <% end %>
+<% if @ossec_custom_alert_output then -%>
+    <custom_alert_output><%= @ossec_custom_alert_output %></custom_alert_output>
+<% end -%>
   </global>
 
 <% if @syslog_output == true then -%>

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -108,6 +108,9 @@
 <% @ossec_ignorepaths.each do |path| -%>
     <ignore><%= path %></ignore>
 <% end -%>
+<% @ossec_ignorepaths_regex.each do |regex| -%>
+    <ignore type="sregex"><%= regex %></ignore>
+<% end -%>
 <% if @ossec_prefilter == true then %>
     <prefilter_cmd>/usr/sbin/prelink -y</prefilter_cmd>
 <% end %>

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -15,9 +15,9 @@
     <host_information><%= @ossec_global_host_information_level %></host_information>
     <% @ossec_white_list.each do |ipaddress| -%><white_list><%= ipaddress %></white_list>
     <% end %>
-<% if @ossec_custom_alert_output then -%>
+    <%- unless @ossec_custom_alert_output.empty? -%>
     <custom_alert_output><%= @ossec_custom_alert_output %></custom_alert_output>
-<% end -%>
+    <%- end -%>
   </global>
 
 <% if @syslog_output == true then -%>

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -144,6 +144,9 @@
   <remote>
     <connection>syslog</connection>
     <port><%= @ossec_syslog_server_port %></port>
+<% @ossec_syslog_allowed_ips.each do |ip| -%>
+    <allowed-ips><%= @ip %></allowed-ips>
+<% end -%>
   </remote>
 <% end -%>
 

--- a/templates/10_ossec_agent.conf.erb
+++ b/templates/10_ossec_agent.conf.erb
@@ -22,6 +22,9 @@
 <% @ossec_ignorepaths.each do |path| -%>
     <ignore><%= path %></ignore>
 <% end -%>
+<% @ossec_ignorepaths_regex.each do |regex| -%>
+    <ignore type="sregex"><%= regex %></ignore>
+<% end -%>
 <% if @ossec_prefilter == true then %>
     <prefilter_cmd>/usr/sbin/prelink -y</prefilter_cmd>
 <% end %>


### PR DESCRIPTION
This PR introduces three new features:

* Configuration of syslog server "remote" on the ossec manager (to receive syslog messages)
* Configuration of `sregex` type ignore paths (on both client and manager)
* Configuration of the `custom_alert_output` option in the ossec manager

The default settings should make NO changes to existing implementations. Changes would only be made when these new options are configured different to their defaults.